### PR TITLE
Fix HTML typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mini map for web pages.
 
 add a `canvas` tag to your HTML page:
 ```html
-<canvas id='#map'></canvas>
+<canvas id='map'></canvas>
 ```
 
 fix it's position on the screen:


### PR DESCRIPTION
This fixes a HTML typo in README where the `id` attribute in HTML `canvas` tag had a `#` before starting.

You need also to fix this in the website: https://larsjung.de/pagemap/
